### PR TITLE
ci(pages-ci.yml): Update Setup Typst to v4

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -50,10 +50,10 @@ jobs:
           path: "fonts/Fira"
 
       - name: 📥 Setup Typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v4
         id: setup-typst
         with:
-          version: "v0.10.0"
+          typst-version: "v0.10.0"
 
       - name: 📄 Setup Pages index.html
         run: |


### PR DESCRIPTION
> [!WARNING] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.